### PR TITLE
Add support for custom audience

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ supplying a `parsedToken` (with all its information in visible form) and the
 
 ```js
 passport.use(new GoogleTokenStrategy({
-      clientID: '12345.abcdefghijkl.apps.googleusercontent.com'// Specify the CLIENT_ID of the app that accesses the backend
-     // Or, if multiple clients access the backend:
-     //[CLIENT_ID_1, CLIENT_ID_2, CLIENT_ID_3]
+      clientID: '12345.abcdefghijkl.apps.googleusercontent.com'// Specify the CLIENT_ID of the backend
+     // If other clients (such as android / ios apps) also access the google api:
+     // audience: [CLIENT_ID_FOR_THE_BACKEND, CLIENT_ID_ANDROID, CLIENT_ID_IOS, CLIENT_ID_SPA]
     },
     function(parsedToken, googleId, done) {
       User.findOrCreate(..., function (err, user) {

--- a/src/strategy.ts
+++ b/src/strategy.ts
@@ -62,6 +62,7 @@ export class GoogleTokenStrategy extends Strategy {
     this.name = 'google-verify-token';
     this.googleAuthClient = new OAuth2Client(this.clientID);
     this.verify = verify;
+    this.audience = options.audience ? options.audience : options.clientID;
   }
 
   /**
@@ -120,9 +121,7 @@ export class GoogleTokenStrategy extends Strategy {
   public verifyGoogleToken(idToken: string, clientID: string | [], done: (...args: any[]) => void) {
     this.googleAuthClient.verifyIdToken(
       {
-        audience: clientID, // Specify the CLIENT_ID of the app that accesses the backend
-        // Or, if multiple clients access the backend:
-        // [CLIENT_ID_1, CLIENT_ID_2, CLIENT_ID_3]
+        audience: this.audience,
         idToken,
       },
       (err, loginTicket) => {

--- a/src/strategy.ts
+++ b/src/strategy.ts
@@ -42,6 +42,7 @@ export class GoogleTokenStrategy extends Strategy {
   public verify: (...args: any[]) => void;
   public clientID: string;
   public passReqToCallback: boolean;
+  public audience: string[];
 
   constructor(options: (() => void) | any, verify?: (...args: any[]) => void) {
     super();


### PR DESCRIPTION
If accepted, this PR will allow developers to customize their audience.
For instance, when using this library in a backend that validates google tokens from both an android and ios app, you'll want to pass both clientIds in the audience field.