### PR TITLE
Support both idTokens and accessTokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ unobtrusively integrated into any application or framework that supports
 ### Configure Strategy
 
 The Google authentication strategy leverages the [Google Auth Library for Node.js](https://github.com/googleapis/google-auth-library-nodejs) to authenticates users. 
-Applications must supply a `verify` callback which accepts the `idToken`
+Applications must supply a `verify` callback which accepts the `idToken` or `access_token`
 coming from the user to be authenticated, and then calls the `done` callback
 supplying a `parsedToken` (with all its information in visible form) and the
 `googleId`.
@@ -43,6 +43,9 @@ passport.use(new GoogleTokenStrategy({
     }
   ));
 ```
+When verifying an idToken, the Google Auth library `verifyIdToken()` function is called, and the authentication is finished. When an `access_token` is passed, however, two steps have to be made:
+1. The Google Auth `getTokenInfo()` function is called. This is to verify that the token is valid and not expired.
+2. A request to `/oauth2/v3/userinfo` is sent. `access_token`s require this second step in order to get the same user information `idToken`s return. 
 
 ### Authenticate Requests
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "license": "MIT",
   "dependencies": {
     "google-auth-library": "^7.0.4",
+    "got": "11",
     "passport-strategy": "^1.0.0"
   },
   "devDependencies": {

--- a/src/strategy.ts
+++ b/src/strategy.ts
@@ -128,11 +128,11 @@ export class GoogleTokenStrategy extends Strategy {
    * @param {Function} done
    * @api protected
    */
-  public verifyGoogleIdToken(token: string, clientID: string | []) {
+  public verifyGoogleIdToken(idToken: string, clientID: string | []) {
     this.googleAuthClient.verifyIdToken(
       {
         audience: this.audience,
-        idToken: token,
+        idToken,
       },
       (err, loginTicket) => {
         if (err) {

--- a/src/strategy.ts
+++ b/src/strategy.ts
@@ -114,7 +114,7 @@ export class GoogleTokenStrategy extends Strategy {
       this.paramFromRequest(req, 'id_token') ||
       this.getBearerToken(req.headers);
 
-    if (idToken) this.verifyGoogleIdToken(idToken, this.clientID)
+    if (idToken) this.verifyGoogleIdToken(idToken)
     else if (accessToken) this.verifyGoogleAccessToken(accessToken)
     else {
       return this.fail({ message: 'no Google authentication token provided' }, 401);
@@ -128,7 +128,7 @@ export class GoogleTokenStrategy extends Strategy {
    * @param {String} clientID
    * @api protected
    */
-  public verifyGoogleIdToken(idToken: string, clientID: string | []) {
+  public verifyGoogleIdToken(idToken: string) {
     this.googleAuthClient.verifyIdToken(
       {
         audience: this.audience,

--- a/src/strategy.ts
+++ b/src/strategy.ts
@@ -103,6 +103,7 @@ export class GoogleTokenStrategy extends Strategy {
    * Authenticate request by verifying the token
    *
    * @param {Object} req
+   * @param {Object} options
    * @api protected
    */
   public authenticate(req: any, options: any) {
@@ -125,7 +126,6 @@ export class GoogleTokenStrategy extends Strategy {
    *
    * @param {String} idToken
    * @param {String} clientID
-   * @param {Function} done
    * @api protected
    */
   public verifyGoogleIdToken(idToken: string, clientID: string | []) {
@@ -151,13 +151,11 @@ export class GoogleTokenStrategy extends Strategy {
    * Ensure getting token info for access token is successful.
    * 
    * @param {String} accessToken
-   * @param {Function} done
    * @api protected
    */
   public verifyGoogleAccessToken(accessToken: string) {
     this.googleAuthClient.getTokenInfo(accessToken).then((tokenInfo) => {
       if (!tokenInfo) {
-        console.log('invalid access token')
         this.done(null, false, {
           message: 'invalid access token'
         })
@@ -166,7 +164,6 @@ export class GoogleTokenStrategy extends Strategy {
       }
 
       if (tokenInfo.expiry_date < Date.now()) {
-        console.log('token expired')
         this.done(null, false, {
           message: 'access token expired'
         })
@@ -178,14 +175,11 @@ export class GoogleTokenStrategy extends Strategy {
       got.get(`https://www.googleapis.com/oauth2/v3/userinfo?access_token=${accessToken}`).then(userinfo => {
         this.done(null, userinfo)
       }).catch(e => {
-        console.log(e)
         this.done(null, false, {
           message: 'failed to get userinfo'
         })
       })
-
     }).catch((e) => {
-      console.log(e)
       this.done(null, false, {
         message: e.message
       })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -43,7 +43,7 @@
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
     // "types": [],                           /* Type declaration files to be included in compilation. */
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-    "esModuleInterop": true, /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
 
     /* Source Map Options */
@@ -55,7 +55,6 @@
     /* Experimental Options */
     // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
-    "moduleResolution": "node16"
   },
   "include": ["src"],
   "exclude": ["node_modules"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -43,7 +43,7 @@
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
     // "types": [],                           /* Type declaration files to be included in compilation. */
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-    "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    "esModuleInterop": true, /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
 
     /* Source Map Options */
@@ -55,6 +55,7 @@
     /* Experimental Options */
     // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+    "moduleResolution": "node16"
   },
   "include": ["src"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
Admittedly this could be a bit of a breaking change, since the `verifyGoogleToken` function is now split into two separate functions.

Adds the ability to verify `idToken`s OR `accessTokens`. The reason some of the commits are fairly old is because we were using this internally as a patch/fork for a while.